### PR TITLE
Allow rtc_s1_static_validity_start_date to be set in config prodict_id

### DIFF
--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -129,6 +129,11 @@ def populate_product_id(product_id, burst_in, processing_datetime,
     # Populate product_id version
     product_id = product_id.replace('{product_version}', f'v{product_version}')
 
+    # Populate the rtc_s1_static_validity_start_date
+    product_id = product_id.replace(
+        "{rtc_s1_static_validity_start_date}", f"{rtc_s1_static_validity_start_date}"
+    )
+
     if not is_mosaic:
         burst_id_file_name = str(burst_in.burst_id).upper().replace('_', '-')
         product_id = product_id.replace('{burst_id}', f'{burst_id_file_name}')


### PR DESCRIPTION
- Bugfix allows the wildcard `{rtc_s1_static_validity_start_date}` to be set in the string for the `product_id` value in the config file, and the value will be set by the pipeline - https://github.com/GeoscienceAustralia/RTC/blob/main/src/rtc/defaults/rtc_s1_static.yaml#L73
- E.g. prior to this fix, if `product_id: ga_{burst_id}_{processing_datetime}_{rtc_s1_static_validity_start_date}` was set, the `burst_id` and `processing_datetime` would be correctly replaced, but the `{rtc_s1_static_validity_start_date}` string would remain in the filename. 