### PR TITLE
Update/data access url format

### DIFF
--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -464,6 +464,15 @@ def get_metadata_dict(product_id: str,
     # create substring "{end_date}"
     end_date_str = burst_in.sensing_stop.strftime('%Y-%m-%d')
 
+    # create substrings for burst acquisition start times (st)
+    # "{burst_st_year}", "{burst_st_month}", "{burst_st_day}", "{burst_st}"
+    burst_st = burst_in.sensing_start.strftime("%Y%m%dT%H%M%S") 
+    burst_st_year, burst_st_month, burst_st_day = (
+        f"{burst_st.year}",
+        f"{burst_st.month:02d}", # zero padded month
+        f"{burst_st.day:02d}", # zero padded day
+    )
+
     # source data access (URL or DOI)
     source_data_access = cfg_in.groups.input_file_group.source_data_access
     if not source_data_access:
@@ -474,9 +483,15 @@ def get_metadata_dict(product_id: str,
     if not product_data_access:
         product_data_access = '(NOT PROVIDED)'
     else:
-        # replace "{burst_id}"" and "{end_date}" substrings
+        # replace "{end_date}" "{burst_id}" "{burst_st_year}",  
+        # "{burst_st_month}", "{burst_st_dat}", "{burst_st}" substrings
         product_data_access = product_data_access.format(
-            burst_id=burst_id_ga, end_date=end_date_str)
+            burst_id=burst_id_ga, 
+            burst_st_year=burst_st_year,
+            burst_st_month=burst_st_month,
+            burst_st_day=burst_st_day,
+            burst_st=burst_st,
+            end_date=end_date_str)
 
     # static layers data access (URL or DOI)
     static_layers_data_access = \
@@ -484,9 +499,15 @@ def get_metadata_dict(product_id: str,
     if not static_layers_data_access:
         static_layers_data_access = '(NOT PROVIDED)'
     else:
-        # replace "{burst_id}"" and "{end_date}" substrings
+        # replace "{end_date}" "{burst_id}" "{burst_st_year}",  
+        # "{burst_st_month}", "{burst_st_day}", "{burst_st}" substrings
         static_layers_data_access = static_layers_data_access.format(
-            burst_id=burst_id_ga, end_date=end_date_str)
+            burst_id=burst_id_ga, 
+            burst_st_year=burst_st_year,
+            burst_st_month=burst_st_month,
+            burst_st_day=burst_st_day,
+            burst_st=burst_st,
+            end_date=end_date_str)
 
     # platform ID
     if burst_in.platform_id == 'S1A':

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -466,12 +466,12 @@ def get_metadata_dict(product_id: str,
 
     # create substrings for burst acquisition start times (st)
     # "{burst_st_year}", "{burst_st_month}", "{burst_st_day}", "{burst_st}"
-    burst_st = burst_in.sensing_start.strftime("%Y%m%dT%H%M%S") 
     burst_st_year, burst_st_month, burst_st_day = (
-        f"{burst_st.year}",
-        f"{burst_st.month:02d}", # zero padded month
-        f"{burst_st.day:02d}", # zero padded day
+        f"{burst_in.sensing_start.year}",
+        f"{burst_in.sensing_start.month:02d}", # zero padded month
+        f"{burst_in.sensing_start.day:02d}", # zero padded day
     )
+    burst_st = burst_in.sensing_start.strftime("%Y%m%dT%H%M%S") 
 
     # source data access (URL or DOI)
     source_data_access = cfg_in.groups.input_file_group.source_data_access


### PR DESCRIPTION
- Given a single cofig is used to run a full scene with multiple bursts, some values in the config need to be updated for each burst. For example, the URL should be burst specific and not for the full scene. Thus, the workflow needs to change some values provided in the config - e.g. https://github.com/GeoscienceAustralia/RTC/blob/main/src/rtc/defaults/rtc_s1.yaml#L78 
- Previously, only the `{burst_id}` and `{end_date}` could be set as wildcards, as this aligns with NASA's storage patterns
- We also want dates to be considered, the following ensures these are correctly set for each burst. Additional strings replaced:
  - `{burst_st_year}`
  -  `{burst_st_month}`
  -  `{burst_st_day}`
  -  `{burst_st}`
- This produces consistent links and metadata across various files (e.g. Geotiffs, STAC.json and .h5). 
- The changes do not impact the pipeline in any other way, if these are not provided they will not be replaced.